### PR TITLE
add client groups API route, fetch script, and unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 
     "fetch:locations": "node ./scripts/fetch-locations.js",
     "fetch:service-categories": "node ./scripts/fetch-service-categories.js",
-    "fetch:all": "npm-run-all fetch:locations fetch:service-categories"
+    "fetch:client-groups": "node ./scripts/fetch-client-groups.js",
+    "fetch:all": "npm-run-all fetch:locations fetch:service-categories fetch:client-groups"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.16.8",

--- a/scripts/fetch-client-groups.js
+++ b/scripts/fetch-client-groups.js
@@ -1,0 +1,45 @@
+// scripts/fetch-client-groups.js
+
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
+
+dotenv.config();
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error('Missing MONGODB_URI in environment');
+  }
+
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    const db = client.db('streetsupport');
+
+    const groups = await db
+      .collection('ClientGroups')
+      .find({})
+      .project({ _id: 1, Key: 1, Name: 1 })
+      .toArray();
+
+    // Transform to use lower camel case for key + name
+    const cleaned = groups.map(g => ({
+      _id: g._id.toString(),
+      key: g.Key,
+      name: g.Name,
+    }));
+
+    const outputPath = path.join('./src/data/client-groups.json');
+    fs.writeFileSync(outputPath, JSON.stringify(cleaned, null, 2));
+
+    console.log(`✅ Client groups saved to ${outputPath}`);
+  } catch (err) {
+    console.error('❌ Failed to fetch client groups:', err);
+  } finally {
+    await client.close();
+  }
+}
+
+main();

--- a/src/app/api/client-groups/helper.ts
+++ b/src/app/api/client-groups/helper.ts
@@ -1,0 +1,20 @@
+// src/app/api/client-groups/helper.ts
+
+import { getClientPromise } from '@/utils/mongodb';
+
+export async function getClientGroups() {
+  const client = await getClientPromise();
+  const db = client.db('streetsupport');
+
+  const groups = await db
+    .collection('ClientGroups')
+    .find({})
+    .project({ _id: 1, Key: 1, Name: 1 })
+    .toArray();
+
+  return groups.map(g => ({
+    _id: g._id,
+    key: g.Key,
+    name: g.Name,
+  }));
+}

--- a/src/app/api/client-groups/route.ts
+++ b/src/app/api/client-groups/route.ts
@@ -1,27 +1,17 @@
+// src/app/api/client-groups/route.ts
+
 import { NextResponse } from 'next/server';
-import { getClientPromise } from '@/utils/mongodb';
+import { getClientGroups } from './helper';
 
 export async function GET() {
   try {
-    const client = await getClientPromise();
-    const db = client.db('streetsupport');
-
-    // Query ClientGroups collection
-    const groups = await db.collection('ClientGroups').find({}).toArray();
-
-    // Shape: id, name, slug (adjust based on actual fields)
-    const output = groups.map((group) => ({
-      id: group._id,
-      name: group.Name,
-      key: group.Key, // If your data uses a Key field
-    }));
-
-    return NextResponse.json({ status: 'success', data: output });
+    const groups = await getClientGroups();
+    return NextResponse.json({ status: 'success', data: groups });
   } catch (error) {
-    console.error(error);
-    return NextResponse.json({
-      status: 'error',
-      message: error instanceof Error ? error.message : 'Unknown error',
-    });
+    console.error('Error fetching client groups:', error);
+    return NextResponse.json(
+      { status: 'error', message: 'Failed to fetch client groups' },
+      { status: 500 }
+    );
   }
 }

--- a/src/data/client-groups.json
+++ b/src/data/client-groups.json
@@ -1,36 +1,172 @@
 [
-  "age-10-24",
-  "age-under-16",
-  "families",
-  "age-under-18",
-  "age-under-19",
-  "age-under-21",
-  "age-under-25",
-  "age-under-26",
-  "age-11-25",
-  "age-16+",
-  "age-16-21",
-  "age-16-24",
-  "age-16-25",
-  "age-18-25",
-  "age-18-30",
-  "age-18+",
-  "age-25+",
-  "age-26+",
-  "age-40+",
-  "male-only",
-  "female-only",
-  "bame",
-  "asylum-seekers",
-  "refugees",
-  "eea-residents",
-  "rough-sleepers",
-  "veterans",
-  "sex-workers",
-  "ex-offenders",
-  "lgbt+",
-  "gay",
-  "lesbian",
-  "bisexual",
-  "transgender"
+  {
+    "_id": "5bd060eb46e3da5220f9c8ba",
+    "key": "refugees",
+    "name": "Refugees"
+  },
+  {
+    "_id": "5bf6b9e323c7a0408e8e6912",
+    "key": "age-18-30",
+    "name": "18-30 only"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8be",
+    "key": "lgbt+",
+    "name": "LGBT+"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8b8",
+    "key": "bame",
+    "name": "Black, Asian and Minority Ethnic"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8bf",
+    "key": "gay",
+    "name": "Gay"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8c1",
+    "key": "bisexual",
+    "name": "Bisexual"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf2e",
+    "key": "age-40+",
+    "name": "40+ only"
+  },
+  {
+    "_id": "5bf4289c23c7a0408e8e690b",
+    "key": "age-16+",
+    "name": "16+ only"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8c2",
+    "key": "transgender",
+    "name": "Transgender"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf27",
+    "key": "age-11-25",
+    "name": "11-25 only"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8b6",
+    "key": "female-only",
+    "name": "Female only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf26",
+    "key": "age-under-21",
+    "name": "Under 21s only"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8b9",
+    "key": "asylum-seekers",
+    "name": "Asylum seekers"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf2c",
+    "key": "age-25+",
+    "name": "25+ only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf2d",
+    "key": "age-26+",
+    "name": "26+ only"
+  },
+  {
+    "_id": "5bf3ee8a23c7a0408e8e6909",
+    "key": "age-under-16",
+    "name": "Under 16s only"
+  },
+  {
+    "_id": "5bf6b9c323c7a0408e8e6911",
+    "key": "age-under-26",
+    "name": "Under 26s only"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8bb",
+    "key": "eea-residents",
+    "name": "EEA residents"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8c0",
+    "key": "lesbian",
+    "name": "Lesbian"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf28",
+    "key": "age-16-21",
+    "name": "16-21 only"
+  },
+  {
+    "_id": "5bf4295323c7a0408e8e690c",
+    "key": "ex-offenders",
+    "name": "Ex-Offenders"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf2a",
+    "key": "age-18-25",
+    "name": "18-25 only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf29",
+    "key": "age-16-25",
+    "name": "16-25 only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf2b",
+    "key": "age-18+",
+    "name": "18+ only"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8b5",
+    "key": "male-only",
+    "name": "Male only"
+  },
+  {
+    "_id": "5bf6b96e23c7a0408e8e6910",
+    "key": "age-10-24",
+    "name": "10-24 only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf24",
+    "key": "age-under-18",
+    "name": "Under 18s only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf25",
+    "key": "age-under-19",
+    "name": "Under 19s only"
+  },
+  {
+    "_id": "5be0274846e3da23605eaf2f",
+    "key": "sex-workers",
+    "name": "Sex workers"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8bc",
+    "key": "rough-sleepers",
+    "name": "Rough sleepers"
+  },
+  {
+    "_id": "5bd060eb46e3da5220f9c8bd",
+    "key": "veterans",
+    "name": "Armed forces veterans"
+  },
+  {
+    "_id": "5bed9f4623c7a0408e8e6904",
+    "key": "age-under-25",
+    "name": "Under 25s only"
+  },
+  {
+    "_id": "5bf435a423c7a0408e8e690d",
+    "key": "age-16-24",
+    "name": "16-24 only"
+  },
+  {
+    "_id": "5f844e470532b71444f305ff",
+    "key": "families",
+    "name": "Families"
+  }
 ]

--- a/tests/__tests__/api/client-groups.test.ts
+++ b/tests/__tests__/api/client-groups.test.ts
@@ -1,0 +1,47 @@
+// tests/__tests__/api/client-groups.test.ts
+
+import { getClientGroups } from '../../../src/app/api/client-groups/helper';
+
+jest.mock('@/utils/mongodb', () => ({
+  getClientPromise: jest.fn(),
+}));
+
+const mockClient = {
+  db: jest.fn().mockReturnThis(),
+  collection: jest.fn().mockReturnThis(),
+  find: jest.fn().mockReturnThis(),
+  project: jest.fn().mockReturnThis(),
+  toArray: jest.fn(),
+};
+
+describe('getClientGroups', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return formatted client groups', async () => {
+    const mockData = [
+      { _id: '1', Key: 'refugees', Name: 'Refugees' },
+      { _id: '2', Key: 'families', Name: 'Families' },
+    ];
+
+    mockClient.toArray.mockResolvedValueOnce(mockData);
+
+    const { getClientPromise } = require('@/utils/mongodb');
+    getClientPromise.mockResolvedValueOnce(mockClient);
+
+    const result = await getClientGroups();
+
+    expect(result).toEqual([
+      { _id: '1', key: 'refugees', name: 'Refugees' },
+      { _id: '2', key: 'families', name: 'Families' },
+    ]);
+  });
+
+  it('should throw if the database call fails', async () => {
+    const { getClientPromise } = require('@/utils/mongodb');
+    getClientPromise.mockRejectedValueOnce(new Error('DB down'));
+
+    await expect(getClientGroups()).rejects.toThrow('DB down');
+  });
+});

--- a/tests/__tests__/scripts/fetch-client-groups.test.ts
+++ b/tests/__tests__/scripts/fetch-client-groups.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+describe('fetch-client-groups script output', () => {
+  it('should create a valid client-groups.json file', () => {
+    const raw = fs.readFileSync('src/data/client-groups.json', 'utf8');
+    const data = JSON.parse(raw);
+
+    expect(Array.isArray(data)).toBe(true);
+    data.forEach(group => {
+      expect(group).toHaveProperty('_id');
+      expect(group).toHaveProperty('key');
+      expect(group).toHaveProperty('name');
+    });
+  });
+});


### PR DESCRIPTION
- Added `/api/client-groups` serverless API route to return all client groups from the database.
- Created a new `fetch-client-groups.js` script to generate a static `client-groups.json` file for local use.
- Refactored route logic into a reusable `getClientGroups` helper for easier unit testing.
- Added Jest unit test for the helper to verify database output and error handling.
- Verified that `clientGroups` are displayed on Find Help but not yet used for filtering — ready for future extension.
